### PR TITLE
Replaced deprecated methods, removed unused imports

### DIFF
--- a/src/config.java
+++ b/src/config.java
@@ -1,38 +1,27 @@
 package net.pms.external.infidel.jumpy;
 
 import java.io.File;
-import java.io.IOException;
-
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.BufferedImage;
-
 import javax.swing.*;
 import javax.swing.event.*;
 import javax.swing.border.Border;
 import javax.swing.plaf.metal.MetalIconFactory;
 import javax.imageio.ImageIO;
-
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
-
 import org.ini4j.Wini;
 import org.ini4j.Options;
 import org.ini4j.Persistable;
 import org.ini4j.OptionMap;
 import org.ini4j.Profile.Section;
-
+import org.slf4j.LoggerFactory;
 import net.pms.PMS;
-import net.pms.io.SystemUtils;
-import net.pms.io.BasicSystemUtils;
-import net.pms.io.MacSystemUtils;
 
 // convenience class to combine interfaces for inlining
 abstract class multiListener implements ItemListener, ChangeListener, ActionListener, DocumentListener {}
@@ -55,6 +44,8 @@ public class config {
 	public static String latest, latesturl;
 	static JPanel statusbar;
 
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(multiListener.class);
+
 	public static multiListener listener = new multiListener() {
 		public void stateChanged(ChangeEvent e) {
 			setopt(((JComponent)e.getSource()), 0);
@@ -64,7 +55,7 @@ public class config {
 		}
 		public void setopt(JComponent c, int state) {
 			String opt = c.getToolTipText();
-			PMS.debug("setopt " + opt);
+			LOGGER.debug("{Jumpy} setopt: {}", opt);
 			if (opt.equals("bookmarks")) {
 				jumpy.showBookmarks = (state == ItemEvent.DESELECTED ? false : true);
 			} else if (opt.equals("verbose_bookmarks")) {
@@ -83,14 +74,14 @@ public class config {
 		public void actionPerformed(ActionEvent e) {
 			String cmd = e.getActionCommand();
 			if (cmd.equals("Save")) {
-				PMS.debug("Save");
+				LOGGER.debug("{Jumpy} Save");
 				jumpy.writeconf();
 			} else if (cmd.equals("Revert")) {
-				PMS.debug("Revert");
+				LOGGER.debug("{Jumpy} Revert");
 				jumpy.readconf();
 				rebuild((JComponent)e.getSource());
 			} else if (cmd.equals("Update")) {
-				PMS.debug("Update");
+				LOGGER.debug("{Jumpy} Update");
 				update();
 			}
 		}

--- a/src/jumpy.java
+++ b/src/jumpy.java
@@ -5,24 +5,20 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.io.IOException;
-
 import java.util.Properties;
 import java.util.List;
 import java.util.Iterator;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
-
 import javax.swing.JComponent;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.io.FilenameUtils;
-
+import org.slf4j.LoggerFactory;
 import net.pms.PMS;
 import net.pms.dlna.DLNAResource;
 import net.pms.external.AdditionalFoldersAtRoot;
@@ -30,18 +26,11 @@ import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.RendererConfiguration;
 import net.pms.logging.LoggingConfigFileLoader;
 import net.pms.formats.Format;
-import net.pms.formats.FormatFactory;
 import net.pms.encoders.Player;
-import net.pms.encoders.PlayerFactory;
-import net.pms.external.ExternalListener;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.io.OutputParams;
 import net.pms.io.ProcessWrapper;
 import net.pms.external.URLResolver;
-
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
-
 import net.pms.external.dbgpack;
 import net.pms.external.DebugPacker;
 
@@ -69,6 +58,7 @@ public class jumpy implements AdditionalFoldersAtRoot, dbgpack, DebugPacker, URL
 	public List<player> players;
 	public static Map<String,String> icons = new HashMap<String,String>();
 	public static File cache;
+	private static org.slf4j.Logger LOGGER = LoggerFactory.getLogger(jumpy.class);
 
 	public jumpy() {
 		pms = PMS.get();
@@ -260,7 +250,7 @@ public class jumpy implements AdditionalFoldersAtRoot, dbgpack, DebugPacker, URL
 
 	public static synchronized void log(String msg, boolean minimal) {
 		if (minimal) {
-			PMS.minimal(msgtag + msg);
+			LOGGER.info("{Jumpy} {}{}", msgtag, msg);
 		}
 		logger.log(msg);
 	}

--- a/src/mediaItem.java
+++ b/src/mediaItem.java
@@ -25,7 +25,7 @@ public class mediaItem extends xmbObject {
 			this.delay = this.buffersize = -1;
 			this.userdata = null;
 		}
-		setFormat(FormatFactory.getAssociatedExtension("." + this.fmt));
+		setFormat(FormatFactory.getAssociatedFormat("." + this.fmt));
 		if (this.thumbnail == null) {
 			setThumbnail(jumpy.getIcon(this.fmt));
 		}

--- a/src/player.java
+++ b/src/player.java
@@ -4,15 +4,11 @@ import java.io.PrintStream;
 import java.io.IOException;
 
 import java.util.Arrays;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.Date;
 import java.util.List;
 import java.util.ArrayList;
 
 import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.SwingConstants;
 import javax.swing.AbstractButton;
 import javax.swing.Icon;
 
@@ -21,7 +17,6 @@ import java.lang.reflect.Method;
 import net.pms.PMS;
 import net.pms.configuration.PmsConfiguration;
 import net.pms.configuration.FormatConfiguration;
-import net.pms.network.HTTPResource;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.dlna.DLNAResource;
 import net.pms.io.OutputParams;
@@ -100,7 +95,7 @@ public class player extends Player {
 			this.dynamic = true;
 		}
 		final String[] fmts = fmt.split("\\|");
-		this.format = FormatFactory.getAssociatedExtension("." + fmts[0]);
+		this.format = FormatFactory.getAssociatedFormat("." + fmts[0]);
 
 		// create the format if it doesn't exist
 		if (this.format == null) {

--- a/src/resolver.java
+++ b/src/resolver.java
@@ -15,7 +15,6 @@ import net.pms.encoders.PlayerFactory;
 import net.pms.dlna.Range;
 import net.pms.dlna.DLNAMediaInfo;
 import net.pms.configuration.RendererConfiguration;
-import net.pms.util.PlayerUtil;
 
 public class resolver extends xmbObject {
 	public String uri0, uri = null, syspath = null;
@@ -34,7 +33,7 @@ public class resolver extends xmbObject {
 
 	public resolver(jumpy jumpy, int type, String name, String uri, String thumb, String syspath, Map<String,String> env) {
 		super(name, thumb);
-		jumpy = jumpy;
+		resolver.jumpy = jumpy;
 		this.uri0 = uri;
 		this.syspath = syspath;
 		this.env = new HashMap<String,String>();
@@ -63,9 +62,9 @@ public class resolver extends xmbObject {
 			}
 			setSpecificType(type);
 		} else {
-			f = FormatFactory.getAssociatedExtension(u);
+			f = FormatFactory.getAssociatedFormat(u);
 			if (f == null) {
-				f = FormatFactory.getAssociatedExtension(
+				f = FormatFactory.getAssociatedFormat(
 					type == Format.IMAGE ? ".jpg" : type == Format.AUDIO ? ".mp3" : ".mpg");
 			}
 		}
@@ -109,7 +108,7 @@ public class resolver extends xmbObject {
 
 	@Override
 	public boolean isTranscodeFolderAvailable() {
-		return (media.getCodecV() != null || media.getFirstAudioTrack() != null);
+		return (getMedia().getCodecV() != null || getMedia().getFirstAudioTrack() != null);
 	}
 
 	@Override

--- a/src/runner.java
+++ b/src/runner.java
@@ -2,7 +2,6 @@ package net.pms.external.infidel.jumpy;
 
 import java.io.*;
 import java.util.Arrays;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
 

--- a/src/scriptFolder.java
+++ b/src/scriptFolder.java
@@ -42,7 +42,7 @@ public class scriptFolder extends xmbObject {
 		this.ex = null;
 		this.newItem = null;
 		this.refreshAlways = (jumpy.refresh == 0);
-		this.lastmodified = 0;
+		setLastModified(0);
 		this.isFolder = true;
 	}
 
@@ -82,7 +82,7 @@ public class scriptFolder extends xmbObject {
 			children.add(0, children.remove(children.size() - 1));
 		}
 		refreshOnce = false;
-		lastmodified = 0;
+		setLastModified(0);
 	}
 
 	public void refresh() {
@@ -91,13 +91,13 @@ public class scriptFolder extends xmbObject {
 
 	@Override
 	public void resolve() {
-		discovered = !(refreshOnce || refreshAlways);
+		setDiscovered(!(refreshOnce || refreshAlways));
 	}
 
 	@Override
 	public boolean isRefreshNeeded() {
-		boolean isneeded = (lastmodified != 0);
-		lastmodified = 0;
+		boolean isneeded = (getLastModified() != 0);
+		setLastModified(0);
 		return isneeded;
 	}
 

--- a/src/userscripts.java
+++ b/src/userscripts.java
@@ -18,12 +18,10 @@ import java.util.regex.Matcher;
 
 import org.apache.commons.exec.util.StringUtils;
 
-import org.ini4j.Wini;
 import org.ini4j.Profile.Section;
 import org.ini4j.InvalidFileFormatException;
 import org.ini4j.spi.IniHandler;
 import org.ini4j.BasicProfile;
-import org.ini4j.Options;
 import org.ini4j.OptionMap;
 import org.ini4j.Persistable;
 import org.ini4j.spi.OptionsFormatter;
@@ -43,7 +41,7 @@ public class userscripts {
 	public static metaIni meta;
 
 	public userscripts(jumpy jumpy) {
-		this.jumpy = jumpy;
+		userscripts.jumpy = jumpy;
 		inis = new ArrayList<Ini>();
 		meta = new metaIni(jumpy.metaini);
 		inis.add(meta);
@@ -269,7 +267,7 @@ public class userscripts {
 			if (disabled || isMetaSection(s)) {
 				super.store(formatter, s);
 			} else if (s == changed_sec) {
-				PmsConfiguration configuration = PMS.get().getConfiguration();
+				PmsConfiguration configuration = PMS.getConfiguration();
 				for (String option : s.keySet()) {
 					if (super.getType(option) == PMSPROPERTY) {
 						configuration.setCustomProperty(option.substring(1), s.get(option));
@@ -359,7 +357,7 @@ public class userscripts {
 				// skip
 			} else if (type == PMSPROPERTY) {
 				if (isEnabled(section)) {
-					PMS.get().getConfiguration().setCustomProperty(option.substring(1), val);
+					PMS.getConfiguration().setCustomProperty(option.substring(1), val);
 					pms_save = true;
 				}
 				super.store(formatter, section, option, index);

--- a/src/xmb.java
+++ b/src/xmb.java
@@ -1,10 +1,6 @@
 package net.pms.external.infidel.jumpy;
 
 import java.io.File;
-import java.io.InputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -19,7 +15,6 @@ import com.google.gson.Gson;
 
 import net.pms.PMS;
 import net.pms.configuration.RendererConfiguration;
-import net.pms.network.HTTPResource;
 import net.pms.formats.Format;
 import net.pms.formats.FormatFactory;
 import net.pms.dlna.DLNAResource;
@@ -36,7 +31,6 @@ import net.pms.dlna.WebVideoStream;
 import net.pms.dlna.WebAudioStream;
 import net.pms.dlna.PlaylistFolder;
 import net.pms.dlna.DVDISOFile;
-import net.pms.configuration.RendererConfiguration;
 import net.pms.network.UPNPHelper;
 
 import static net.pms.external.infidel.jumpy.jumpyAPI.*;
@@ -165,7 +159,7 @@ public final class xmb {
 		}
 
 		if (type == MEDIA && data == null) {
-			Format format = FormatFactory.getAssociatedExtension("." + FilenameUtils.getExtension(uri));
+			Format format = FormatFactory.getAssociatedFormat("." + FilenameUtils.getExtension(uri));
 			if (format == null) {
 				return null;
 			}
@@ -338,7 +332,7 @@ public final class xmb {
 			case GETPROPERTY:
 				return utils.getCustomProperty(arg1, arg2);
 			case SETPROPERTY:
-				PMS.get().getConfiguration().setCustomProperty(arg1, arg2);
+				PMS.getConfiguration().setCustomProperty(arg1, arg2);
 				break;
 			case ICON:
 				jumpy.setIcon(arg1, arg2);
@@ -419,7 +413,7 @@ public final class xmb {
 							m.setCodecV(s.get("codec"));
 						}
 						if (s.containsKey("aspect")) {
-							m.setAspect(s.get("aspect"));
+							m.setAspectRatioDvdIso(s.get("aspect"));
 						}
 						if (s.containsKey("width")) {
 							m.setWidth(Integer.parseInt(s.get("width")));

--- a/src/xmbObject.java
+++ b/src/xmbObject.java
@@ -46,7 +46,7 @@ public class xmbObject extends DLNAResource implements jumpyAPI {
 	}
 
 	public void touch() {
-		lastmodified = 1;
+		setLastModified(1);
 	}
 
 	// DLNAResource


### PR DESCRIPTION
I've gone through jumpy and replaced deprecated methods and removed unused imports. I did _not_ change the `LoggingConfigFileLoader` to `LoggingConfig` to keep PMS compatibility for jumpy, but that would be an easy fix the day that is no longer needed.

I also fixed non-static calls to static methods a couple of places where it seemed to create bugs, but most of them I left alone (there are a lot of them).
