### PR TITLE
Update methods to align with UMS > 6.5.2

### DIFF
--- a/src/player.java
+++ b/src/player.java
@@ -118,10 +118,6 @@ public class player extends Player implements jumpyAPI {
 					return true;
 				}
 				@Override
-				public boolean ps3compatible() {
-					return true;
-				}
-				@Override
 				public Identifier getIdentifier() {
 					return Identifier.CUSTOM;
 				}
@@ -130,12 +126,12 @@ public class player extends Player implements jumpyAPI {
 					return self.id;
 				}
 				@Override
-				public boolean skip(String extensions, String moreExtensions) {
+				public boolean skip(String... extensions) {
 					return true; // always force transcode
 				}
 			};
 			this.format.setType(this.type);
-			FormatFactory.getSupportedFormats().add(0, this.format/*.duplicate()*/);
+			FormatFactory.addFormat(this.format/*.duplicate()*/);
 		}
 		if (this.mimetype == null) {
 			this.mimetype = this.format.mimeType();

--- a/src/player.java
+++ b/src/player.java
@@ -3,6 +3,7 @@ package net.pms.external.infidel.jumpy;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -131,7 +132,7 @@ public class player extends Player implements jumpyAPI {
 				}
 			};
 			this.format.setType(this.type);
-			FormatFactory.addFormat(this.format/*.duplicate()*/);
+			addFormat(this.format/*.duplicate()*/);
 		}
 		if (this.mimetype == null) {
 			this.mimetype = this.format.mimeType();
@@ -498,6 +499,17 @@ public class player extends Player implements jumpyAPI {
 	@Override
 	public Object getTag() {
 		return apiObj.getTag();
+	}
+
+	public static void addFormat(Format format) {
+		try {
+			Method method = FormatFactory.class.getMethod("addFormat", Format.class);
+			method.invoke(null, format);
+			return;
+		} catch (Exception e) {
+			// Wrong version, do it the "old way"
+		}
+		FormatFactory.getSupportedFormats().add(0, format);
 	}
 }
 

--- a/src/utils.java
+++ b/src/utils.java
@@ -195,7 +195,7 @@ public final class utils {
 		if (ffmpeg_hdr.contains("--enable-librtmp")) {
 			properties.put("librtmp", "true");
 			if (FormatFactory.getAssociatedFormat("rtmp://?") == null) {
-				FormatFactory.addFormat(new WEB() {
+				player.addFormat(new WEB() {
 					@Override
 					public String[] getSupportedExtensions() {
 						return (new String[] {"rtmp", "rtmpt", "rtmps", "rtmpe", "rtmfp", "rtmpte", "rtmpts"});

--- a/src/utils.java
+++ b/src/utils.java
@@ -150,7 +150,7 @@ public final class utils {
 			sub.setId(100); // fake id, not used
 			sub.setLang(lang);
 			sub.setType(SubtitleType.valueOfFileExtension(FilenameUtils.getExtension(path)));
-			sub.setExternalFile(new File(path));
+			sub.setExternalFile(new File(path), null);
 			try {
 				d.setMediaSubtitle(sub); // ums
 			} catch (Throwable t) {
@@ -195,7 +195,7 @@ public final class utils {
 		if (ffmpeg_hdr.contains("--enable-librtmp")) {
 			properties.put("librtmp", "true");
 			if (FormatFactory.getAssociatedFormat("rtmp://?") == null) {
-				FormatFactory.getSupportedFormats().add(0, new WEB() {
+				FormatFactory.addFormat(new WEB() {
 					@Override
 					public String[] getSupportedExtensions() {
 						return (new String[] {"rtmp", "rtmpt", "rtmps", "rtmpe", "rtmfp", "rtmpte", "rtmpts"});


### PR DESCRIPTION
@skeptical I know you hate changes to the API, but this was necessary. I don't know any other way to make this thread-safe and it manifested itself after some additional tests were created - so the problem has been there all along.

There's no way to add them first in the "new API" as you used to do. Although that could easily be changed, I'm not sure I see the need/if that will make any difference. Is that important?